### PR TITLE
PADV-2235 feat: create an openedx-filter to provide enroll emails with extra parameters

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -442,3 +442,20 @@ class VerticalBlockChildRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(block=block, context=context)
         return data.get("block"), data.get("context")
+
+
+class GetEnrollEmailNotificationExtraParameters(OpenEdxPublicFilter):
+    """
+    Custom class used to provide with extra parameters to email enroll notifications.
+    """
+
+    filter_type = "org.openedx.learning.course.enrollment.email-notification-extra-params.v1"
+
+    @classmethod
+    def run_filter(cls, course_key):
+        """
+        Execute a filter with the signature specified.
+        Arguments:
+            course_key (CourseKey): course key associated with the enrollment.
+        """
+        return super().run_pipeline(course_key=course_key)

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -1,7 +1,7 @@
 """
 Tests for learning subdomain filters.
 """
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from ddt import data, ddt, unpack
 from django.test import TestCase
@@ -15,6 +15,7 @@ from openedx_filters.learning.filters import (
     CourseEnrollmentStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
+    GetEnrollEmailNotificationExtraParameters,
     StudentLoginRequested,
     StudentRegistrationRequested,
     VerticalBlockChildRenderStarted,
@@ -413,3 +414,27 @@ class TestCohortFilters(TestCase):
         result = CohortAssignmentRequested.run_filter(user, target_cohort)
 
         self.assertTupleEqual((user, target_cohort,), result)
+
+
+class TestGetEnrollEmailNotificationExtraParameters(TestCase):
+    """
+    Test suite for the GetEnrollEmailNotificationExtraParameters public filter.
+    """
+
+    @patch("openedx_filters.learning.filters.OpenEdxPublicFilter.run_pipeline")
+    def test_run_filter_delegates_to_pipeline(self, mock_run_pipeline):
+        """
+        Should call run_pipeline with course_key and return the result.
+        """
+        mock_course_key = MagicMock()
+        expected_result = {
+            "institution_name": "Test Institution",
+            "institution_admin_email": "admin@example.com",
+        }
+
+        mock_run_pipeline.return_value = expected_result
+
+        result = GetEnrollEmailNotificationExtraParameters.run_filter(mock_course_key)
+
+        mock_run_pipeline.assert_called_once_with(course_key=mock_course_key)
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
### Tickets
https://agile-jira.pearson.com/browse/PADV-2235

### Description
We need to add a new OpenEdxPublicFilter to enrich the enrollment notification emails with institution-specific data, such as the institution name and the email of its administrator. 

### Changes Made

-  Created GetEnrollEmailNotificationExtraParameters as an OpenEdxPublicFilter.
-  Test functions

### How to test

Follow the steps of: https://github.com/Pearson-Advance/edx-platform/pull/153