### PR TITLE
feat: add SessionJWTCreationRequested filter.

### DIFF
--- a/openedx_filters/authentication/__init__.py
+++ b/openedx_filters/authentication/__init__.py
@@ -1,0 +1,6 @@
+"""
+Package where events related to the ``authentication`` subdomain are implemented.
+
+The ``authentication`` subdomain corresponds to {Architecture Subdomain} defined in OEP-41.
+https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0041-arch-async-server-event-messaging.html
+"""

--- a/openedx_filters/authentication/filters.py
+++ b/openedx_filters/authentication/filters.py
@@ -1,0 +1,42 @@
+"""
+Package where filters related to the ``authentication`` architectural subdomain are implemented.
+"""
+from typing import Any, Dict, Tuple
+
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class SessionJWTCreationRequested(OpenEdxPublicFilter):
+    """
+    Filter used to update the JWT token's payload by adding extra data when its creation is requested.
+
+    Purpose:
+        This filter is triggered when the JWT token's creation is requested, and grants the possibility to add new
+        additional data to it.
+
+    Filter Type:
+        org.openedx.authentication.session.jwt.creation.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: openedx/core/djangoapps/oauth_dispatch/jwt.py
+        - Function or Method: _create_jwt
+    """
+
+    filter_type = "org.openedx.authentication.session.jwt.creation.requested.v1"
+
+    def run_filter(cls, payload: Dict[str, Any], user: Any) -> Tuple[Dict[str, Any], Any]:
+        """
+        Process the inputs using the configured pipeline steps to modify the payload of the JWT token.
+
+        Arguments:
+            payload (str): the payload of JWT token to be modified.
+            user (User): Django User related to the JWT token.
+
+        Returns:
+            tuple[dict, User]:
+                - dict: the modified payload of the JWT token.
+                - User: the user of the JWT token.
+        """
+        data = super().run_pipeline(payload=payload, user=user)
+        return data.get('payload', {}), data.get('user')

--- a/openedx_filters/authentication/tests/__init__.py
+++ b/openedx_filters/authentication/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Package where unit tests for ``authentication`` subdomain filters are located.
+"""

--- a/openedx_filters/authentication/tests/test_filters.py
+++ b/openedx_filters/authentication/tests/test_filters.py
@@ -1,0 +1,58 @@
+"""
+Tests for ``authentication`` subdomain filters.
+"""
+from unittest.mock import Mock, patch
+
+from openedx_filters.authentication.filters import SessionJWTCreationRequested
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class TestSessionJWTCreationRequested():
+    """
+    Test class to verify standard behavior of the filters located in rendering views.
+    You'll find test suites for:
+
+    - SessionJWTCreationRequested
+    """
+
+    def test_session_jwt_creation_requested(self):
+        """
+        Test SessionJWTCreationRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the payload and the user.
+        """
+        payload = {'key': 'value'}
+        modified_payload = {'key': 'modified_value'}
+        user = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            'run_pipeline',
+            return_value={'payload': modified_payload, 'user': user},
+        ) as mock_run_pipeline:
+            payload_result, user_result = SessionJWTCreationRequested.run_filter(payload, user)
+
+            mock_run_pipeline.assert_called_once_with(payload=payload, user=user)
+            self.assertEqual(modified_payload, payload_result)
+            self.assertEqual(user, user_result)
+
+    def test_session_jwt_creation_requested_missing_payload(self):
+        """
+        Test SessionJWTCreationRequested filter behavior when the payload is missing.
+
+        Expected behavior:
+            - The filter should return an empty payload and the user.
+        """
+        user = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            'run_pipeline',
+            return_value={'payload': {}, 'user': user},
+        ) as mock_run_pipeline:
+            payload_result, user_result = SessionJWTCreationRequested.run_filter(None, user)
+
+            mock_run_pipeline.assert_called_once_with(payload=None, user=user)
+            self.assertEqual({}, payload_result)
+            self.assertEqual(user, user_result)


### PR DESCRIPTION
## Description

This PR adds a new filter that updates the JWT token's payload of a User by adding extra data when its creation is requested. The filter receives the payload and the User object, and returns the User and the modified payload with any new data included. For example: adds a new field with the permission roles of a certain subproject. Other uses could include: adding the last access datetime of the User, a status, or any other useful information related to the User.

## Installation instructions
- Install course_operations.
- Install openedx-filters including the changes from this PR: change the openedx-filters requirement so it uses this fork and PR: git+https://github.com/Pearson-Advance/openedx-filters.git@pearson-release/olive.main

## Testing instructions
- Call the run_filter method from SessionJWTCreationRequested with a given payload and a user.
- Check that the permission_roles are valid for that user.
