### PR TITLE
feat: add classmethod decorator to SessionJWTCreationRequested.

### DIFF
--- a/openedx_filters/authentication/filters.py
+++ b/openedx_filters/authentication/filters.py
@@ -25,6 +25,7 @@ class SessionJWTCreationRequested(OpenEdxPublicFilter):
 
     filter_type = "org.openedx.authentication.session.jwt.creation.requested.v1"
 
+    @classmethod
     def run_filter(cls, payload: Dict[str, Any], user: Any) -> Tuple[Dict[str, Any], Any]:
         """
         Process the inputs using the configured pipeline steps to modify the payload of the JWT token.


### PR DESCRIPTION
## Description

We need to add a classmethod decorator to the `run_filter` method for the SessionJWTCreationRequested filter to work properly.

## Installation instructions
- Install course_operations.
- Install openedx-filters including the changes from this PR: change the openedx-filters requirement so it uses this fork and PR: git+https://github.com/Pearson-Advance/openedx-filters.git@pearson-release/olive.main

## Testing instructions
- Call the run_filter method from SessionJWTCreationRequested with a given payload and a user.
- Check that the permission_roles are valid for that user.
