### PR TITLE
feat: add license_enforcement filters.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, pearson/ulmo]
   pull_request:
     branches:
     - '**'

--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1445,3 +1445,39 @@ class ScheduleQuerySetRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(schedules=schedules)
         return data.get("schedules")
+
+
+class GetEnrollEmailNotificationExtraParameters(OpenEdxPublicFilter):
+    """
+    Filter used to provide additional context parameters for enrollment email notifications.
+
+    Purpose:
+        This filter is triggered when an enrollment-related email notification
+        is being prepared, allowing downstream extensions to inject extra
+        parameters into the email context.
+
+    Filter Type:
+        org.openedx.learning.course.enrollment.email-notification-extra-params.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: lms/djangoapps/instructor/enrollment.py
+        - Function or Method: send_mail_to_student.
+    """
+
+    filter_type = "org.openedx.learning.course.enrollment.email-notification-extra-params.v1"
+
+    @classmethod
+    def run_filter(cls, course_key):
+        """
+        Execute the filter pipeline to collect extra parameters for
+        enrollment email notifications.
+
+        Arguments:
+            course_key (CourseKey): The course key associated with the enrollment.
+
+        Returns:
+            dict: A dictionary containing additional parameters to be merged
+            into the enrollment email context.
+        """
+        return super().run_pipeline(course_key=course_key)

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -1,7 +1,7 @@
 """
 Tests for learning subdomain filters.
 """
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 # Ignore the type error for ddt import since it is not recognized by mypy.
 from ddt import data, ddt, unpack  # type: ignore
@@ -22,6 +22,7 @@ from openedx_filters.learning.filters import (
     CourseRunAPIRenderStarted,
     CourseUnenrollmentStarted,
     DashboardRenderStarted,
+    GetEnrollEmailNotificationExtraParameters,
     IDVPageURLRequested,
     InstructorDashboardRenderStarted,
     ORASubmissionViewRenderStarted,
@@ -801,3 +802,27 @@ class TestScheduleFilters(TestCase):
         result = ScheduleQuerySetRequested.run_filter(schedules)
 
         self.assertEqual(schedules, result)
+
+
+class TestGetEnrollEmailNotificationExtraParameters(TestCase):
+    """
+    Test suite for the GetEnrollEmailNotificationExtraParameters public filter.
+    """
+
+    @patch("openedx_filters.learning.filters.OpenEdxPublicFilter.run_pipeline")
+    def test_run_filter_delegates_to_pipeline(self, mock_run_pipeline):
+        """
+        Should call run_pipeline with course_key and return the result.
+        """
+        mock_course_key = MagicMock()
+        expected_result = {
+            "institution_name": "Test Institution",
+            "institution_admin_email": "admin@example.com",
+        }
+
+        mock_run_pipeline.return_value = expected_result
+
+        result = GetEnrollEmailNotificationExtraParameters.run_filter(mock_course_key)
+
+        mock_run_pipeline.assert_called_once_with(course_key=mock_course_key)
+        self.assertEqual(result, expected_result)

--- a/openedx_filters/license_enforcement/__init__.py
+++ b/openedx_filters/license_enforcement/__init__.py
@@ -1,0 +1,7 @@
+"""
+Package where filters related to the ``license_enforcement`` architectural subdomain are implemented.
+
+These filters expose licensing and permission decisions as public extension points,
+allowing external plugins to participate in CCX-related authorization and enforcement
+logic without direct coupling to implementation details.
+"""

--- a/openedx_filters/license_enforcement/filters.py
+++ b/openedx_filters/license_enforcement/filters.py
@@ -1,0 +1,261 @@
+"""
+Package where filters related to the ``license_enforcement`` architectural subdomain are implemented.
+"""
+from __future__ import annotations
+
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class CourseLicensingEnabledRequested(OpenEdxPublicFilter):
+    """
+    Filter used to determine whether course licensing is enabled for the current site.
+
+    Purpose:
+        This filter is triggered when platform code needs to know whether course
+        licensing enforcement should be applied. It allows external plugins to
+        compute this value, typically based on site configuration.
+
+    Filter Type:
+        org.openedx.learning.course_licensing.enabled.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: common/djangoapps/student (or CCX integration layer)
+        - Function or Method: CcxCourseTab.is_enabled (and other licensing checks)
+    """
+
+    filter_type = "org.openedx.learning.course_licensing.enabled.requested.v1"
+
+    @classmethod
+    def run_filter(cls, *, enabled: bool = False) -> bool:
+        """
+        Process the configured pipeline steps to determine whether course licensing
+        is enabled.
+
+        Arguments:
+            enabled (bool): Default value used when no pipeline step overrides it.
+
+        Returns:
+            bool:
+                True if course licensing is enabled; False otherwise.
+        """
+        data = super().run_pipeline(enabled=enabled)
+        return bool(data.get("enabled", enabled))
+
+
+class CcxEnrollmentLicenseEnforcementRequested(OpenEdxPublicFilter):
+    """
+    Filter used to determine whether enrollment or invitation into a CCX is allowed
+    under licensing rules.
+
+    Purpose:
+        This filter is triggered when an enrollment or invitation action is requested
+        for a CCX. It allows external plugins to enforce seat limits, license status,
+        institutional rules, and enrollment privileges.
+
+    Filter Type:
+        org.openedx.learning.ccx.enrollment.license_enforcement.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: enrollment / CCX invitation workflows
+        - Function or Method: enrollment or invitation validation logic
+    """
+
+    filter_type = "org.openedx.learning.ccx.enrollment.license_enforcement.requested.v1"
+
+    @classmethod
+    def run_filter(
+        cls,
+        *,
+        course_key,
+        email=None,
+        student=None,
+        request=None,
+        user=None,
+        allowed: bool = True,
+    ) -> bool:
+        """
+        Process the configured pipeline steps to determine whether the enrollment
+        or invitation is allowed.
+
+        Arguments:
+            course_key (CCXLocator): Identifier of the CCX.
+            email (str, optional): Email of the user to be invited.
+            student (User, optional): Existing platform user to be enrolled.
+            request (HttpRequest, optional): HTTP request initiating the action.
+            user (User, optional): User who initiated the enrollment.
+            allowed (bool): Initial allowance value, used for composition.
+
+        Returns:
+            bool:
+                True if enrollment/invitation is allowed; False otherwise.
+        """
+        data = super().run_pipeline(
+            course_key=course_key,
+            email=email,
+            student=student,
+            request=request,
+            user=user,
+            allowed=allowed,
+        )
+        return bool(data.get("allowed", allowed))
+
+
+class CcxLicensedStatusRequested(OpenEdxPublicFilter):
+    """
+    Filter used to determine whether a CCX is covered by an active license.
+
+    Purpose:
+        This filter is triggered when platform code needs to know whether a CCX
+        is licensed and therefore subject to licensing-based restrictions.
+
+    Filter Type:
+        org.openedx.learning.ccx.licensed_status.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: CCX access and visibility checks
+        - Function or Method: CCX authorization helpers
+    """
+
+    filter_type = "org.openedx.learning.ccx.licensed_status.requested.v1"
+
+    @classmethod
+    def run_filter(cls, *, course_id, licensed: bool = False) -> bool:
+        """
+        Process the configured pipeline steps to determine whether the CCX
+        is licensed.
+
+        Arguments:
+            course_id (CCXLocator): Identifier of the CCX.
+            licensed (bool): Default licensing status.
+
+        Returns:
+            bool:
+                True if the CCX is licensed; False otherwise.
+        """
+        data = super().run_pipeline(course_id=course_id, licensed=licensed)
+        return bool(data.get("licensed", licensed))
+
+
+class CcxCoachTabAccessRequested(OpenEdxPublicFilter):
+    """
+    Filter used to determine whether a user is allowed to access the CCX coach tab.
+
+    Purpose:
+        This filter is triggered when rendering CCX navigation elements and allows
+        external plugins to restrict access to the CCX coach dashboard based on
+        licensing and role-based rules.
+
+    Filter Type:
+        org.openedx.learning.ccx.coach_tab.access.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: xmodule / course tabs
+        - Function or Method: CcxCourseTab.is_enabled
+    """
+
+    filter_type = "org.openedx.learning.ccx.coach_tab.access.requested.v1"
+
+    @classmethod
+    def run_filter(cls, *, user, ccx_id, allowed: bool = False) -> bool:
+        """
+        Process the configured pipeline steps to determine whether the user
+        is allowed to access the CCX coach tab.
+
+        Arguments:
+            user (User): Django user requesting access.
+            ccx_id (CCXLocator): Identifier of the CCX.
+            allowed (bool): Default access decision.
+
+        Returns:
+            bool:
+                True if the user may access the CCX coach tab; False otherwise.
+        """
+        data = super().run_pipeline(user=user, ccx_id=ccx_id, allowed=allowed)
+        return bool(data.get("allowed", allowed))
+
+
+class CcxCreationPermissionRequested(OpenEdxPublicFilter):
+    """
+    Filter used to determine whether a user is allowed to create a CCX from a master course.
+
+    Purpose:
+        This filter is triggered during CCX creation workflows to allow external
+        plugins to enforce licensing and institutional constraints on who may
+        create CCXs.
+
+    Filter Type:
+        org.openedx.learning.ccx.creation.permission.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: CCX creation views / APIs
+        - Function or Method: CCX creation validation logic
+    """
+
+    filter_type = "org.openedx.learning.ccx.creation.permission.requested.v1"
+
+    @classmethod
+    def run_filter(cls, *, user, master_course, allowed: bool = True) -> bool:
+        """
+        Process the configured pipeline steps to determine whether the user
+        is allowed to create a CCX.
+
+        Arguments:
+            user (User): Django user requesting CCX creation.
+            master_course (CourseLocator): Master course identifier.
+            allowed (bool): Initial permission value.
+
+        Returns:
+            bool:
+                True if the user may create a CCX; False otherwise.
+        """
+        data = super().run_pipeline(
+            user=user,
+            master_course=master_course,
+            allowed=allowed,
+        )
+        return bool(data.get("allowed", allowed))
+
+
+class CcxPendingEnrollmentsRequested(OpenEdxPublicFilter):
+    """
+    Filter used to retrieve pending enrollments for a licensed CCX.
+
+    Purpose:
+        This filter is triggered when platform code needs to retrieve the list
+        of users pending enrollment into a CCX, allowing external plugins to
+        provide or modify the data source.
+
+    Filter Type:
+        org.openedx.learning.ccx.pending_enrollments.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: CCX administration views
+        - Function or Method: pending enrollment retrieval logic
+    """
+
+    filter_type = "org.openedx.learning.ccx.pending_enrollments.requested.v1"
+
+    @classmethod
+    def run_filter(cls, *, ccx_id, pending_enrollments=None):
+        """
+        Process the configured pipeline steps to retrieve pending enrollments.
+
+        Arguments:
+            ccx_id (CCXLocator): Identifier of the CCX.
+            pending_enrollments (QuerySet | None): Default pending enrollments.
+
+        Returns:
+            QuerySet:
+                A queryset (or iterable) of pending enrollments.
+        """
+        data = super().run_pipeline(
+            ccx_id=ccx_id,
+            pending_enrollments=pending_enrollments,
+        )
+        return data.get("pending_enrollments", pending_enrollments)

--- a/openedx_filters/license_enforcement/tests/__init__.py
+++ b/openedx_filters/license_enforcement/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Package where unit tests for ``license_enforcement`` subdomain filters are located.
+"""

--- a/openedx_filters/license_enforcement/tests/test_filters.py
+++ b/openedx_filters/license_enforcement/tests/test_filters.py
@@ -1,0 +1,391 @@
+"""
+Tests for ``license_enforcement`` subdomain filters.
+"""
+import unittest
+from unittest.mock import Mock, patch
+
+from openedx_filters.license_enforcement.filters import (
+    CcxCoachTabAccessRequested,
+    CcxCreationPermissionRequested,
+    CcxEnrollmentLicenseEnforcementRequested,
+    CcxLicensedStatusRequested,
+    CcxPendingEnrollmentsRequested,
+    CourseLicensingEnabledRequested,
+)
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+
+class TestCourseLicensingEnabledRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in license_enforcement.
+
+    - CourseLicensingEnabledRequested
+    """
+
+    def test_filter_type(self):
+        """Verify the filter type remains stable."""
+        self.assertEqual(
+            "org.openedx.learning.course_licensing.enabled.requested.v1",
+            CourseLicensingEnabledRequested.filter_type,
+        )
+
+    def test_course_licensing_enabled_requested(self):
+        """
+        Test CourseLicensingEnabledRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the 'enabled' value from the pipeline.
+        """
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"enabled": True},
+        ) as mock_run_pipeline:
+            result = CourseLicensingEnabledRequested.run_filter(enabled=False)
+
+            mock_run_pipeline.assert_called_once_with(enabled=False)
+            self.assertTrue(result)
+
+    def test_course_licensing_enabled_requested_missing_enabled(self):
+        """
+        Test CourseLicensingEnabledRequested filter behavior when 'enabled' is missing.
+
+        Expected behavior:
+            - The filter should return the default 'enabled' value passed to run_filter.
+        """
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},
+        ) as mock_run_pipeline:
+            result = CourseLicensingEnabledRequested.run_filter(enabled=True)
+
+            mock_run_pipeline.assert_called_once_with(enabled=True)
+            self.assertTrue(result)
+
+
+class TestCcxEnrollmentLicenseEnforcementRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in license_enforcement.
+
+    - CcxEnrollmentLicenseEnforcementRequested
+    """
+
+    def test_filter_type(self):
+        """Verify the filter type remains stable."""
+        self.assertEqual(
+            "org.openedx.learning.ccx.enrollment.license_enforcement.requested.v1",
+            CcxEnrollmentLicenseEnforcementRequested.filter_type,
+        )
+
+    def test_ccx_enrollment_license_enforcement_requested(self):
+        """
+        Test CcxEnrollmentLicenseEnforcementRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the 'allowed' value from the pipeline.
+        """
+        course_key = Mock()
+        email = "learner@example.com"
+        student = Mock()
+        request = Mock()
+        user = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"allowed": False},
+        ) as mock_run_pipeline:
+            result = CcxEnrollmentLicenseEnforcementRequested.run_filter(
+                course_key=course_key,
+                email=email,
+                student=student,
+                request=request,
+                user=user,
+                allowed=True,
+            )
+
+            mock_run_pipeline.assert_called_once_with(
+                course_key=course_key,
+                email=email,
+                student=student,
+                request=request,
+                user=user,
+                allowed=True,
+            )
+            self.assertFalse(result)
+
+    def test_ccx_enrollment_license_enforcement_requested_missing_allowed(self):
+        """
+        Test CcxEnrollmentLicenseEnforcementRequested filter behavior when 'allowed' is missing.
+
+        Expected behavior:
+            - The filter should return the default 'allowed' value passed to run_filter.
+        """
+        course_key = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},
+        ) as mock_run_pipeline:
+            result = CcxEnrollmentLicenseEnforcementRequested.run_filter(
+                course_key=course_key,
+                allowed=False,
+            )
+
+            mock_run_pipeline.assert_called_once_with(
+                course_key=course_key,
+                email=None,
+                student=None,
+                request=None,
+                user=None,
+                allowed=False,
+            )
+            self.assertFalse(result)
+
+
+class TestCcxLicensedStatusRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in license_enforcement.
+
+    - CcxLicensedStatusRequested
+    """
+
+    def test_filter_type(self):
+        """Verify the filter type remains stable."""
+        self.assertEqual(
+            "org.openedx.learning.ccx.licensed_status.requested.v1",
+            CcxLicensedStatusRequested.filter_type,
+        )
+
+    def test_ccx_licensed_status_requested(self):
+        """
+        Test CcxLicensedStatusRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the 'licensed' value from the pipeline.
+        """
+        course_id = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"licensed": True},
+        ) as mock_run_pipeline:
+            result = CcxLicensedStatusRequested.run_filter(course_id=course_id, licensed=False)
+
+            mock_run_pipeline.assert_called_once_with(course_id=course_id, licensed=False)
+            self.assertTrue(result)
+
+    def test_ccx_licensed_status_requested_missing_licensed(self):
+        """
+        Test CcxLicensedStatusRequested filter behavior when 'licensed' is missing.
+
+        Expected behavior:
+            - The filter should return the default 'licensed' value passed to run_filter.
+        """
+        course_id = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},
+        ) as mock_run_pipeline:
+            result = CcxLicensedStatusRequested.run_filter(course_id=course_id, licensed=True)
+
+            mock_run_pipeline.assert_called_once_with(course_id=course_id, licensed=True)
+            self.assertTrue(result)
+
+
+class TestCcxCoachTabAccessRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in license_enforcement.
+
+    - CcxCoachTabAccessRequested
+    """
+
+    def test_filter_type(self):
+        """Verify the filter type remains stable."""
+        self.assertEqual(
+            "org.openedx.learning.ccx.coach_tab.access.requested.v1",
+            CcxCoachTabAccessRequested.filter_type,
+        )
+
+    def test_ccx_coach_tab_access_requested(self):
+        """
+        Test CcxCoachTabAccessRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the 'allowed' value from the pipeline.
+        """
+        user = Mock()
+        ccx_id = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"allowed": True},
+        ) as mock_run_pipeline:
+            result = CcxCoachTabAccessRequested.run_filter(user=user, ccx_id=ccx_id, allowed=False)
+
+            mock_run_pipeline.assert_called_once_with(user=user, ccx_id=ccx_id, allowed=False)
+            self.assertTrue(result)
+
+    def test_ccx_coach_tab_access_requested_missing_allowed(self):
+        """
+        Test CcxCoachTabAccessRequested filter behavior when 'allowed' is missing.
+
+        Expected behavior:
+            - The filter should return the default 'allowed' value passed to run_filter.
+        """
+        user = Mock()
+        ccx_id = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},
+        ) as mock_run_pipeline:
+            result = CcxCoachTabAccessRequested.run_filter(user=user, ccx_id=ccx_id, allowed=False)
+
+            mock_run_pipeline.assert_called_once_with(user=user, ccx_id=ccx_id, allowed=False)
+            self.assertFalse(result)
+
+
+class TestCcxCreationPermissionRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in license_enforcement.
+
+    - CcxCreationPermissionRequested
+    """
+
+    def test_filter_type(self):
+        """Verify the filter type remains stable."""
+        self.assertEqual(
+            "org.openedx.learning.ccx.creation.permission.requested.v1",
+            CcxCreationPermissionRequested.filter_type,
+        )
+
+    def test_ccx_creation_permission_requested(self):
+        """
+        Test CcxCreationPermissionRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the 'allowed' value from the pipeline.
+        """
+        user = Mock()
+        master_course = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"allowed": False},
+        ) as mock_run_pipeline:
+            result = CcxCreationPermissionRequested.run_filter(
+                user=user,
+                master_course=master_course,
+                allowed=True,
+            )
+
+            mock_run_pipeline.assert_called_once_with(
+                user=user,
+                master_course=master_course,
+                allowed=True,
+            )
+            self.assertFalse(result)
+
+    def test_ccx_creation_permission_requested_missing_allowed(self):
+        """
+        Test CcxCreationPermissionRequested filter behavior when 'allowed' is missing.
+
+        Expected behavior:
+            - The filter should return the default 'allowed' value passed to run_filter.
+        """
+        user = Mock()
+        master_course = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},
+        ) as mock_run_pipeline:
+            result = CcxCreationPermissionRequested.run_filter(
+                user=user,
+                master_course=master_course,
+                allowed=False,
+            )
+
+            mock_run_pipeline.assert_called_once_with(
+                user=user,
+                master_course=master_course,
+                allowed=False,
+            )
+            self.assertFalse(result)
+
+
+class TestCcxPendingEnrollmentsRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in license_enforcement.
+
+    - CcxPendingEnrollmentsRequested
+    """
+
+    def test_filter_type(self):
+        """Verify the filter type remains stable."""
+        self.assertEqual(
+            "org.openedx.learning.ccx.pending_enrollments.requested.v1",
+            CcxPendingEnrollmentsRequested.filter_type,
+        )
+
+    def test_ccx_pending_enrollments_requested(self):
+        """
+        Test CcxPendingEnrollmentsRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the 'pending_enrollments' from the pipeline.
+        """
+        ccx_id = Mock()
+        pending_enrollments = Mock()  # could be a QuerySet in real code
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"pending_enrollments": pending_enrollments},
+        ) as mock_run_pipeline:
+            result = CcxPendingEnrollmentsRequested.run_filter(
+                ccx_id=ccx_id,
+                pending_enrollments=None,
+            )
+
+            mock_run_pipeline.assert_called_once_with(
+                ccx_id=ccx_id,
+                pending_enrollments=None,
+            )
+            self.assertEqual(pending_enrollments, result)
+
+    def test_ccx_pending_enrollments_requested_missing_pending_enrollments(self):
+        """
+        Test CcxPendingEnrollmentsRequested filter behavior when 'pending_enrollments' is missing.
+
+        Expected behavior:
+            - The filter should return the default pending_enrollments passed to run_filter.
+        """
+        ccx_id = Mock()
+        default_pending = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},
+        ) as mock_run_pipeline:
+            result = CcxPendingEnrollmentsRequested.run_filter(
+                ccx_id=ccx_id,
+                pending_enrollments=default_pending,
+            )
+
+            mock_run_pipeline.assert_called_once_with(
+                ccx_id=ccx_id,
+                pending_enrollments=default_pending,
+            )
+            self.assertEqual(default_pending, result)


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-2726

## Description

This PR introduces new Open edX **public filter contracts** (Hooks Extension Framework / OEP-50) to support the `license_enforcement` architectural subdomain, exposing CCX licensing and authorization decisions as explicit, versioned filter interfaces.

The new `license_enforcement` filters formalize integration points so downstream licensing plugins can participate via `OPEN_EDX_FILTERS_CONFIG` pipelines (instead of ad-hoc/implicit extension semantics), improving decoupling from edx-platform implementation details and aligning with current Open edX extensibility patterns.

In addition, this PR adds a small `learning` subdomain filter to allow extensions to inject **extra context parameters** into enrollment-related email notifications.

All new filters include detailed docstrings (purpose, trigger, inputs/outputs, defaults) and unit tests validating pipeline delegation and default behavior. CI is also updated so pushes to `pearson/ulmo` trigger the workflow (in addition to `main`).

## Changes made

- [x] Added `license_enforcement` subdomain package (`openedx_filters/license_enforcement`)
- [x] Added license enforcement filters implemented using `OpenEdxPublicFilter`:
  - `CourseLicensingEnabledRequested` (`org.openedx.learning.course_licensing.enabled.requested.v1`)
  - `CcxEnrollmentLicenseEnforcementRequested` (`org.openedx.learning.ccx.enrollment.license_enforcement.requested.v1`)
  - `CcxLicensedStatusRequested` (`org.openedx.learning.ccx.licensed_status.requested.v1`)
  - `CcxCoachTabAccessRequested` (`org.openedx.learning.ccx.coach_tab.access.requested.v1`)
  - `CcxCreationPermissionRequested` (`org.openedx.learning.ccx.creation.permission.requested.v1`)
  - `CcxPendingEnrollmentsRequested` (`org.openedx.learning.ccx.pending_enrollments.requested.v1`)
- [x] Added `learning` filter to provide extra enrollment email notification context parameters:
  - `GetEnrollEmailNotificationExtraParameters` (`org.openedx.learning.course.enrollment.email-notification-extra-params.v1`)
- [x] Added/updated unit tests for the new filters (learning + license_enforcement), validating pipeline behavior and default fallbacks
- [x] Improved documentation and discoverability via detailed filter docstrings
- [x] Updated GitHub Actions CI workflow to run on pushes to `pearson/ulmo` in addition to `main`

## How to test

- Run unit tests for the new/updated packages:

`pytest openedx_filters/license_enforcement/tests openedx_filters/learning/tests`

- Or run the full suite:

`pytest`

- If using unittest directly:

`python -m unittest openedx_filters.license_enforcement.tests.test_filters openedx_filters.learning.tests.test_filters`

- Optional runtime verification: Configure a pipeline step in `OPEN_EDX_FILTERS_CONFIG` for one of the new filter types and confirm the override is applied at runtime (e.g., CCX creation permission, coach tab access, enrollment/invitation enforcement, pending enrollments retrieval, or enrollment email extra params).

## Reviewers

- [x] @JuanDavidBuitrago 
- [x] @luisfelipec95