### PR TITLE
PADV-3010 feat: add a filter to customize the terms of service

### DIFF
--- a/openedx_filters/learning/filters.py
+++ b/openedx_filters/learning/filters.py
@@ -1481,3 +1481,37 @@ class GetEnrollEmailNotificationExtraParameters(OpenEdxPublicFilter):
             into the enrollment email context.
         """
         return super().run_pipeline(course_key=course_key)
+
+
+class StudentTermsOfServiceRequested(OpenEdxPublicFilter):
+    """
+    Filter used to act on terms of service label for registration form.
+
+    Purpose:
+        This filter is triggered when a user requests the register view, just before
+        the page is rendered allowing the filter to act on the terms of service label.
+
+    Filter Type:
+        org.openedx.learning.student.terms_of_service.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: core/djangoapps/user_authn/views/registration_form.py
+        - Function or Method: _add_terms_of_service_field
+    """
+
+    filter_type = "org.openedx.learning.student.terms_of_service.requested.v1"
+
+    @classmethod
+    def run_filter(cls, label: str) -> str | None:
+        """
+        Process the label using the configured pipeline steps to modify the terms of service label.
+
+        Arguments:
+            label (str): The terms of service label to be modified.
+
+        Returns:
+            str: The modified terms of service label.
+        """
+        data = super().run_pipeline(label=label)
+        return data.get("label")

--- a/openedx_filters/learning/tests/test_filters.py
+++ b/openedx_filters/learning/tests/test_filters.py
@@ -30,6 +30,7 @@ from openedx_filters.learning.filters import (
     ScheduleQuerySetRequested,
     StudentLoginRequested,
     StudentRegistrationRequested,
+    StudentTermsOfServiceRequested,
     VerticalBlockChildRenderStarted,
     VerticalBlockRenderCompleted,
 )
@@ -826,3 +827,26 @@ class TestGetEnrollEmailNotificationExtraParameters(TestCase):
 
         mock_run_pipeline.assert_called_once_with(course_key=mock_course_key)
         self.assertEqual(result, expected_result)
+
+
+class TestStudentTermsOfServiceRequested(TestCase):
+    """
+    Test class to verify standard behavior of the student terms of service filters.
+    You'll find test suites for:
+
+    - StudentTermsOfServiceRequested
+    """
+
+    def test_student_terms_of_service_requested(self):
+        """
+        Test StudentTermsOfServiceRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter must have the signature specified.
+            - The filter should return form data.
+        """
+        label = Mock()
+
+        result = StudentTermsOfServiceRequested.run_filter(label)
+
+        self.assertEqual(label, result)


### PR DESCRIPTION
## Description

This PR adds a new filter to customize the terms of service label.

## Related PRs

- https://github.com/Pearson-Advance/edx-platform/pull/186
-

## Hot to test

## Ticket
