### PR TITLE
feat: add public filters for student logout and registration ToS customization.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,14 @@ pip-log.txt
 coverage.xml
 htmlcov/
 
-
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 # The Silver Searcher
 .agignore

--- a/openedx_filters/authentication/filters.py
+++ b/openedx_filters/authentication/filters.py
@@ -41,3 +41,83 @@ class SessionJWTCreationRequested(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(payload=payload, user=user)
         return data.get('payload', {}), data.get('user')
+
+
+class StudentLogoutRequested(OpenEdxPublicFilter):
+    """
+    Filter used to perform custom actions when a user logs out of the LMS.
+
+    Purpose:
+        This filter is triggered to propagate logout to external SSO/IdP, revoke 3rd-party sessions
+        and audit/telemetry side effects.
+
+    Filter Type:
+        org.openedx.learning.student.logout.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: openedx/core/djangoapps/user_authn/views/logout.py
+        - Function or Method: LogoutView.dispatch
+    """
+
+    filter_type = "org.openedx.learning.student.logout.requested.v1"
+
+    @classmethod
+    def run_filter(cls, request):
+        """
+        Execute the configured pipeline.
+
+        Args:
+            request: Django HttpRequest for the logout request.
+
+        Returns:
+            The (possibly modified) request. For most use-cases this is unchanged.
+        """
+        data: dict[str, Any] | Any = super().run_pipeline(request=request)
+
+        if isinstance(data, dict):
+            return data.get("request", request)
+
+        return request
+
+
+class StudentRegistrationFormTermsOfServiceLabelRequested(OpenEdxPublicFilter):
+    """
+    Filter used to modify the Terms of Service field label in the registration form description.
+
+    Purpose:
+        This filter allows extensions or plugins to customize or replace the
+        Terms of Service label displayed on the registration form, for example
+        to inject institution-specific wording, branding, or legal language
+        based on the platform or site context.
+
+    Filter Type:
+        org.openedx.learning.student.registration.form.terms_of_service.label.requested.v1
+
+    Trigger:
+        - Repository: openedx/edx-platform
+        - Path: openedx/core/djangoapps/user_authn/views/register.py
+        - Function or Method: _add_terms_of_service_field
+    """
+
+    filter_type = "org.openedx.learning.student.registration.form.terms_of_service.label.requested.v1"
+
+    @classmethod
+    def run_filter(cls, label: Any, platform_name: str) -> Any:
+        """
+        Run the filter pipeline to optionally override the Terms of Service label
+        shown on the registration form.
+
+        Args:
+            label (Any): Default Terms of Service label.
+            platform_name (str): Current platform or site identifier.
+
+        Returns:
+            Any: The overridden label if provided by a filter, otherwise the original.
+        """
+        data: Any = super().run_pipeline(label=label, platform_name=platform_name)
+
+        if isinstance(data, dict):
+            return data.get("label", label)
+
+        return label

--- a/openedx_filters/authentication/tests/test_filters.py
+++ b/openedx_filters/authentication/tests/test_filters.py
@@ -4,7 +4,11 @@ Tests for ``authentication`` subdomain filters.
 import unittest
 from unittest.mock import Mock, patch
 
-from openedx_filters.authentication.filters import SessionJWTCreationRequested
+from openedx_filters.authentication.filters import (
+    SessionJWTCreationRequested,
+    StudentLogoutRequested,
+    StudentRegistrationFormTermsOfServiceLabelRequested,
+)
 from openedx_filters.tooling import OpenEdxPublicFilter
 
 
@@ -56,3 +60,170 @@ class TestSessionJWTCreationRequested(unittest.TestCase):
             mock_run_pipeline.assert_called_once_with(payload=None, user=user)
             self.assertEqual({}, payload_result)
             self.assertEqual(user, user_result)
+
+
+class TestStudentLogoutRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the filters located in learning.
+
+    - StudentLogoutRequested
+    """
+
+    def test_student_logout_requested_returns_modified_request(self):
+        """
+        Test StudentLogoutRequested filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter should return the request provided by the pipeline output.
+        """
+        request = Mock()
+        modified_request = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"request": modified_request},
+        ) as mock_run_pipeline:
+            request_result = StudentLogoutRequested.run_filter(request)
+
+            mock_run_pipeline.assert_called_once_with(request=request)
+            self.assertEqual(modified_request, request_result)
+
+    def test_student_logout_requested_missing_request_in_pipeline_output(self):
+        """
+        Test StudentLogoutRequested behavior when the pipeline output does not include 'request'.
+
+        Expected behavior:
+            - The filter should return the original request.
+        """
+        request = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},  # no "request" key
+        ) as mock_run_pipeline:
+            request_result = StudentLogoutRequested.run_filter(request)
+
+            mock_run_pipeline.assert_called_once_with(request=request)
+            self.assertEqual(request, request_result)
+
+    def test_student_logout_requested_non_dict_pipeline_output(self):
+        """
+        Test StudentLogoutRequested behavior when the pipeline returns a non-dict value.
+
+        Expected behavior:
+            - The filter should return the original request.
+        """
+        request = Mock()
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value="not-a-dict",
+        ) as mock_run_pipeline:
+            request_result = StudentLogoutRequested.run_filter(request)
+
+            mock_run_pipeline.assert_called_once_with(request=request)
+            self.assertEqual(request, request_result)
+
+
+class TestStudentRegistrationFormTermsOfServiceLabelRequested(unittest.TestCase):
+    """
+    Test class to verify standard behavior of the registration form label filter.
+
+    - StudentRegistrationFormTermsOfServiceLabelRequested
+    """
+
+    def test_terms_of_service_label_requested_returns_modified_label(self):
+        """
+        Test filter behavior under normal conditions.
+
+        Expected behavior:
+            - The filter returns the modified label from the pipeline output.
+        """
+        label = "default label"
+        platform_name = "My Platform"
+        modified_label = "modified label"
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={"label": modified_label},
+        ) as mock_run_pipeline:
+            result = StudentRegistrationFormTermsOfServiceLabelRequested.run_filter(
+                label=label,
+                platform_name=platform_name,
+            )
+
+            mock_run_pipeline.assert_called_once_with(label=label, platform_name=platform_name)
+            self.assertEqual(modified_label, result)
+
+    def test_terms_of_service_label_requested_missing_label_in_pipeline_output(self):
+        """
+        Test behavior when pipeline output does not contain 'label'.
+
+        Expected behavior:
+            - The filter returns the original label.
+        """
+        label = "default label"
+        platform_name = "My Platform"
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value={},  # no "label" key
+        ) as mock_run_pipeline:
+            result = StudentRegistrationFormTermsOfServiceLabelRequested.run_filter(
+                label=label,
+                platform_name=platform_name,
+            )
+
+            mock_run_pipeline.assert_called_once_with(label=label, platform_name=platform_name)
+            self.assertEqual(label, result)
+
+    def test_terms_of_service_label_requested_non_dict_pipeline_output(self):
+        """
+        Test behavior when the pipeline returns a non-dict.
+
+        Expected behavior:
+            - The filter returns the original label.
+        """
+        label = "default label"
+        platform_name = "My Platform"
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value="not-a-dict",
+        ) as mock_run_pipeline:
+            result = StudentRegistrationFormTermsOfServiceLabelRequested.run_filter(
+                label=label,
+                platform_name=platform_name,
+            )
+
+            mock_run_pipeline.assert_called_once_with(label=label, platform_name=platform_name)
+            self.assertEqual(label, result)
+
+    def test_terms_of_service_label_requested_none_pipeline_output(self):
+        """
+        Test behavior when the pipeline returns None.
+
+        Expected behavior:
+            - The filter returns the original label.
+        """
+        label = "default label"
+        platform_name = "My Platform"
+
+        with patch.object(
+            OpenEdxPublicFilter,
+            "run_pipeline",
+            return_value=None,
+        ) as mock_run_pipeline:
+            result = StudentRegistrationFormTermsOfServiceLabelRequested.run_filter(
+                label=label,
+                platform_name=platform_name,
+            )
+
+            mock_run_pipeline.assert_called_once_with(label=label, platform_name=platform_name)
+            self.assertEqual(label, result)


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-3015

## Description

This PR introduces two new **Open edX public filters** to enable platform and plugin extensibility around **student logout handling** and **registration Terms of Service (ToS) label customization**. Both filters follow the standard `OpenEdxPublicFilter` contract and are designed to be safe, non-breaking, and fully optional.

## Changes made

### 1. `StudentLogoutRequested`
- **Filter type:** `org.openedx.learning.student.logout.requested.v1`
- **Trigger:** `LogoutView.dispatch` during LMS logout
- **Purpose:**  
  Allows extensions to hook into the student logout flow to:
  - Propagate logout to external SSO / IdP systems
  - Revoke third-party sessions
  - Perform audit or telemetry side effects

- **Behavior guarantees:**
  - Returns a modified request if provided by the pipeline
  - Falls back to the original request when:
    - Pipeline output is missing the `request` key
    - Pipeline output is not a dict
    - Pipeline output is `None`

### 2. `StudentRegistrationFormTermsOfServiceLabelRequested`
- **Filter type:**  
  `org.openedx.learning.student.registration.form.terms_of_service.label.requested.v1`
- **Trigger:** `_add_terms_of_service_field` during registration form construction
- **Purpose:**  
  Enables customization or replacement of the ToS label text on the registration form, supporting:
  - Institution-specific wording
  - Branding requirements
  - Legal or jurisdiction-specific language
  - Platform-specific variations

- **Behavior guarantees:**
  - Returns a modified label if provided by the pipeline
  - Safely falls back to the default label when:
    - Pipeline output is missing the `label` key
    - Pipeline output is not a dict
    - Pipeline output is `None`

## Tests

- Added comprehensive unit tests covering:
  - Normal pipeline behavior
  - Missing keys in pipeline output
  - Non-dict pipeline responses
  - `None` pipeline responses
- Ensures filters are **fail-safe** and do not break core LMS behavior when unused.

## Backward Compatibility

- No existing filters or behavior are modified.
- Filters are opt-in and have no effect unless explicitly implemented by an extension.
- Safe defaults ensure zero impact on existing deployments.

## PRs related

- https://github.com/Pearson-Advance/tutor-pearson-plugin/pull/1224
- https://github.com/Pearson-Advance/pearson-core/pull/68
- https://github.com/Pearson-Advance/edx-platform/pull/187

## Reviewers

- [ ] @JuanDavidBuitrago
